### PR TITLE
Release for v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.12](https://github.com/Songmu/rcpr/compare/v0.0.11...v0.0.12) - 2022-08-24
+- adjust default pull request body by @Songmu in https://github.com/Songmu/rcpr/pull/52
+- fix remote name detection by @Songmu in https://github.com/Songmu/rcpr/pull/54
+
 ## [v0.0.11](https://github.com/Songmu/rcpr/compare/v0.0.10...v0.0.11) - 2022-08-21
 - fix config key to rcpr.vPrefix from rcpr.v-prefix by @Songmu in https://github.com/Songmu/rcpr/pull/50
 - reload version file after cherry-picking process by @Songmu in https://github.com/Songmu/rcpr/pull/51

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package rcpr
 
-const version = "0.0.11"
+const version = "0.0.12"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.12 created by [rcpr](https://github.com/Songmu/rcpr). Merging it will tag v0.0.12 to the merge commit and create a GitHub release.

You can modify this branch rcpr-v0.0.11 directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .rcpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "rcpr:minor" or "rcpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* adjust default pull request body by @Songmu in https://github.com/Songmu/rcpr/pull/52
* fix remote name detection by @Songmu in https://github.com/Songmu/rcpr/pull/54


**Full Changelog**: https://github.com/Songmu/rcpr/compare/v0.0.11...v0.0.12
